### PR TITLE
Fix typo in spanish translation

### DIFF
--- a/translations/ES.ini
+++ b/translations/ES.ini
@@ -4664,7 +4664,7 @@ PERFORM_ON_COMMAND_SESSION2="**¿Deseas abrir sesiones separadas?**\n\nLa sesió
 ; "There are some opened files. Please close them before exiting application.\n \nBeware: If you ignore this message, opened files may remain in temporary directory."
 PENDING_EDITORS="Quedan algunos archivos abiertos. Se deben cerrar antes de salir de la aplicación.\n \nCuidado: Si ignora este mensaje, los archivos editados permanecerán en el directorio temporal."
 ; "**Do you want to delete past temporary folders?**\n\nWinSCP has found %d temporary folders, which it has probably created in past. These folders may contain files previously edited or downloaded.\n\nYou may also open the folders to review their content and to delete them yourself."
-CLEANTEMP_CONFIRM2="**¿Desea eliminar carpetas temorales?**\n\nWinSCP ha encontrado %d carpetas temporales. Estas carpetas pueden contener archivos previamente editados o descargados.\n\nSi lo deseas puedes revisar estas carpetas y eliminar el contenido manualmente."
+CLEANTEMP_CONFIRM2="**¿Desea eliminar carpetas temporales?**\n\nWinSCP ha encontrado %d carpetas temporales. Estas carpetas pueden contener archivos previamente editados o descargados.\n\nSi lo deseas puedes revisar estas carpetas y eliminar el contenido manualmente."
 ; "&Open"
 OPEN_BUTTON="&Abrir"
 ; "Never show this message a&gain"


### PR DESCRIPTION
Add missing 'p' to word 'temporales'