### PR TITLE
Minor typo

### DIFF
--- a/source/forms/Preferences.dfm
+++ b/source/forms/Preferences.dfm
@@ -966,7 +966,7 @@ object PreferencesDialog: TPreferencesDialog
           Width = 389
           Height = 74
           Anchors = [akLeft, akTop, akRight]
-          Caption = 'Compare directory criterions'
+          Caption = 'Compare directory criteria'
           TabOrder = 2
           DesignSize = (
             389


### PR DESCRIPTION
The word “criteria”, which is a plural form of “criterion”, is much more general than “criterions”.
- Reference: https://books.google.com/ngrams/graph?content=criteria%2Ccriterions&year_start=1900&year_end=2008