### PR TITLE
allow 'WinSCP.targets' flow transitively to any consuming project

### DIFF
--- a/deployment/WinSCPnet.nuspec
+++ b/deployment/WinSCPnet.nuspec
@@ -30,6 +30,7 @@ The NuGet package includes the assembly itself and a required WinSCP executable.
     <file src="$DotNetBuildConfigDir$\netstandard2.0\WinSCPnet.dll" target="lib\netstandard2.0"/>
     <file src="$BuildConfigDir$\WinSCP.exe" target="tools"/>
     <file src="WinSCP.targets" target="build"/>
+    <file src="WinSCP.targets" target="buildTransitive"/>
     <file src="winscp64.png" target=""/>
   </files>
 </package>


### PR DESCRIPTION
With current version (5.19.2), WinSCP.exe does not get copied if WinSCP package is included as transitive dependency. 
This is solved by placing _WinSCP.targets_  within _buildTransitive_ rather than _build_ folder.

For more info see [MS-docs](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets) and [feature-description](https://github.com/NuGet/Home/wiki/Allow-package--authors-to-define-build-assets-transitive-behavior).