### PR TITLE
New function

### DIFF
--- a/dotnet/Session.cs
+++ b/dotnet/Session.cs
@@ -1541,6 +1541,33 @@ namespace WinSCP
             }
         }
 
+        public bool TryGetFileInfo(string path, out RemoteFileInfo fileInfo)
+        {
+            using (CreateCallstackAndLock())
+            {
+                CheckOpened();
+
+                try
+                {
+                    _ignoreFailed = true;
+                    try
+                    {
+                        fileInfo = DoGetFileInfo(path);
+                    }
+                    finally
+                    {
+                        _ignoreFailed = false;
+                    }
+                    return true;
+                }
+                catch (SessionRemoteException)
+                {
+                    fileInfo = null;
+                    return false;
+                }
+            }
+        }
+
         public bool FileExists(string path)
         {
             using (CreateCallstackAndLock())


### PR DESCRIPTION
Instead of calling FileExists and only then GetFileInfo call the TryGetFileInfo function once and you will know if the file exists and also gets its information.