### PR TITLE
Support SSH `Include` directive

### DIFF
--- a/source/core/Configuration.cpp
+++ b/source/core/Configuration.cpp
@@ -1685,7 +1685,7 @@ bool __fastcall TConfiguration::AnyFilezillaSessionForImport(TStoredSessionList 
   }
 }
 //---------------------------------------------------------------------
-static UnicodeString GetOpensshFolder()
+UnicodeString TConfiguration::GetOpensshFolder()
 {
   UnicodeString ProfilePath = GetShellFolderPath(CSIDL_PROFILE);
   UnicodeString Result = TPath::Combine(ProfilePath, OpensshFolderName);

--- a/source/core/Configuration.h
+++ b/source/core/Configuration.h
@@ -334,6 +334,7 @@ public:
     TStrings * Lines, TStoredSessionList * Sessions, UnicodeString & Error);
   TStoredSessionList * SelectOpensshSessionsForImport(TStoredSessionList * Sessions, UnicodeString & Error);
   UnicodeString GetPuttySessionsKey(const UnicodeString & RootKey);
+  UnicodeString GetOpensshFolder();
   void RefreshPuttySshHostCAList();
 
   __property TVSFixedFileInfo *FixedApplicationInfo  = { read=GetFixedApplicationInfo };


### PR DESCRIPTION
This PR adds support for parsing of [`Include`](https://man7.org/linux/man-pages/man5/ssh_config.5.html#:~:text=appear%0A%20%20%20%20%20%20%20%20%20%20%20%20%20before%20it.-,Include,-Include%20the%20specified) directive used in ssh config file during the sites import process