### PR TITLE
Add Interfaces For Ease of Use

### DIFF
--- a/dotnet/CommandExecutionResult.cs
+++ b/dotnet/CommandExecutionResult.cs
@@ -5,7 +5,7 @@ namespace WinSCP
     [Guid("70C312F8-9A09-4D9B-B8EC-FB6ED753892B")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class CommandExecutionResult : OperationResultBase
+    public sealed class CommandExecutionResult : OperationResultBase, ICommandExecutionResult
     {
         public string Output { get; internal set; }
         public string ErrorOutput { get; internal set; }

--- a/dotnet/FilePermissions.cs
+++ b/dotnet/FilePermissions.cs
@@ -7,7 +7,7 @@ namespace WinSCP
     [Guid("90A290B2-C8CE-4900-8C42-7736F9E435C6")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class FilePermissions
+    public sealed class FilePermissions : IFilePermissions
     {
         public int Numeric
         {

--- a/dotnet/Interfaces/IEventArgs.cs
+++ b/dotnet/Interfaces/IEventArgs.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace WinSCP
+{
+    public interface ITransferEventArgs
+    {
+        string FileName { get; }
+        string Destination { get; }
+        TransferOptions Upload { get; }
+        bool Touch { get; }
+        ChmodEventArgs Chmod { get; }
+        RemovalEventArgs Removal { get; }
+        SessionRemoteException Error { get; }
+        ProgressSide Side { get; }
+    }
+    
+    [System.CLSCompliant(false)]
+    public interface IFileTransferProgressEventArgs
+    {
+        string FileName { get; }
+        string Directory { get; }
+        ProgressSide Side { get; }
+        double FileProgress { get; }
+        double OverallProgress { get; }
+        uint CPS { get; }
+    }
+    
+    public interface IFailedEventArgs
+    {
+        string FileName { get; }
+        string Directory { get; }
+        SessionException Error { get; }
+    }
+    
+    public interface IRemovalEventArgs
+    {
+        string FileName { get; }
+        SessionRemoteException Error { get; }
+    }
+    
+    public interface IChmodEventArgs
+    {
+        string FileName { get; }
+        FilePermissions FilePermissions { get; }
+        SessionRemoteException Error { get; }
+    }
+    
+    public interface ITouchEventArgs
+    {
+        string FileName { get; }
+        DateTime LastWriteTime { get; }
+        SessionRemoteException Error { get; }
+    }
+    
+    public interface IQueryReceivedEventArgs
+    {
+        string Query { get; }
+        bool Result { get; set; }
+    }
+    
+    public interface IOutputDataReceivedEventArgs
+    {
+        string Data { get; }
+    }
+}

--- a/dotnet/Interfaces/IOperationResult.cs
+++ b/dotnet/Interfaces/IOperationResult.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace WinSCP
+{
+    public interface IOperationResultBase
+    {
+        bool IsSuccess { get; }
+        SessionRemoteExceptionCollection Failures { get; }
+        
+        void Check();
+    }
+    
+    public interface ITransferOperationResult : IOperationResultBase
+    {
+        TransferEventArgsCollection Transfers { get; }
+    }
+    
+    public interface IRemovalOperationResult : IOperationResultBase
+    {
+        RemovalEventArgsCollection Removals { get; }
+    }
+    
+    public interface ISynchronizationResult : IOperationResultBase
+    {
+        TransferEventArgsCollection Downloads { get; }
+        TransferEventArgsCollection Uploads { get; }
+        RemovalEventArgsCollection Removals { get; }
+    }
+    
+    public interface ICommandExecutionResult
+    {
+        string Output { get; }
+        string ErrorOutput { get; }
+        int ExitCode { get; }
+        bool IsSuccess { get; }
+    }
+}

--- a/dotnet/Interfaces/IRemoteFileInfo.cs
+++ b/dotnet/Interfaces/IRemoteFileInfo.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace WinSCP
+{
+    public interface IRemoteFileInfo
+    {
+        string Name { get; }
+        string FullName { get; }
+        char FileType { get; }
+        long Length { get; }
+        int Length32 { get; set; }
+        DateTime LastWriteTime { get; }
+        FilePermissions FilePermissions { get; }
+        string Owner { get; }
+        string Group { get; }
+        bool IsDirectory { get; }
+        bool IsThisDirectory { get; }
+        bool IsParentDirectory { get; }
+    }
+    
+    public interface IRemoteDirectoryInfo
+    {
+        RemoteFileInfoCollection Files { get; }
+    }
+    
+    public interface IFilePermissions
+    {
+        string Text { get; set; }
+        string Octal { get; set; }
+        int Numeric { get; set; }
+        
+        bool UserExecute { get; set; }
+        bool UserRead { get; set; }
+        bool UserWrite { get; set; }
+        bool GroupExecute { get; set; }
+        bool GroupRead { get; set; }
+        bool GroupWrite { get; set; }
+        bool OtherExecute { get; set; }
+        bool OtherRead { get; set; }
+        bool OtherWrite { get; set; }
+        
+        bool Sticky { get; set; }
+        bool SetUid { get; set; }
+        bool SetGid { get; set; }
+    }
+}

--- a/dotnet/Interfaces/ISession.cs
+++ b/dotnet/Interfaces/ISession.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+#if !NETSTANDARD
+using System.Security;
+#endif
+
+namespace WinSCP
+{
+    public interface ISession : IDisposable
+    {
+        string ExecutablePath { get; set; }
+#if !NETSTANDARD
+        string ExecutableProcessUserName { get; set; }
+        SecureString ExecutableProcessPassword { get; set; }
+#endif
+        string AdditionalExecutableArguments { get; set; }
+        bool DisableVersionCheck { get; set; }
+        TimeSpan ReconnectTime { get; set; }
+        int ReconnectTimeInMilliseconds { get; set; }
+        string DebugLogPath { get; set; }
+        int DebugLogLevel { get; set; }
+        string SessionLogPath { get; set; }
+        string XmlLogPath { get; set; }
+        bool XmlLogPreserve { get; set; }
+        string HomePath { get; }
+        TimeSpan Timeout { get; set; }
+        StringCollection Output { get; }
+        bool Opened { get; }
+
+        event FileTransferredEventHandler FileTransferred;
+        event FailedEventHandler Failed;
+        event OutputDataReceivedEventHandler OutputDataReceived;
+        event FileTransferProgressEventHandler FileTransferProgress;
+        event QueryReceivedEventHandler QueryReceived;
+
+        void Abort();
+        void Open(SessionOptions sessionOptions);
+        string ScanFingerprint(SessionOptions sessionOptions, string algorithm);
+        void Close();
+        
+        RemoteDirectoryInfo ListDirectory(string path);
+        IEnumerable<RemoteFileInfo> EnumerateRemoteFiles(string path, string mask, EnumerationOptions options);
+        
+        TransferOperationResult PutFiles(string localPath, string remotePath, bool remove = false, TransferOptions options = null);
+        TransferOperationResult PutFilesToDirectory(string localPath, string remoteDirectory, string mask = null, bool remove = false, TransferOptions options = null);
+        TransferEventArgs PutFileToDirectory(string localFilePath, string remoteDirectory, bool remove = false, TransferOptions options = null);
+        void PutFile(Stream stream, string remoteFilePath, TransferOptions options = null);
+        
+        TransferOperationResult GetFiles(string remotePath, string localPath, bool remove = false, TransferOptions options = null);
+        TransferOperationResult GetFilesToDirectory(string remotePath, string localDirectory, string mask = null, bool remove = false, TransferOptions options = null);
+        TransferEventArgs GetFileToDirectory(string remoteFilePath, string localDirectory, bool remove = false, TransferOptions options = null);
+        Stream GetFile(string remoteFilePath, TransferOptions options = null);
+        
+        RemovalOperationResult RemoveFiles(string path);
+        RemovalEventArgs RemoveFile(string path);
+        
+        SynchronizationResult SynchronizeDirectories(
+            SynchronizationMode mode, string localPath, string remotePath, 
+            bool removeFiles, bool mirror = false, SynchronizationCriteria criteria = SynchronizationCriteria.Time, 
+            TransferOptions options = null);
+        
+        ComparisonDifferenceCollection CompareDirectories(
+            SynchronizationMode mode, string localPath, string remotePath,
+            bool removeFiles, bool mirror = false, SynchronizationCriteria criteria = SynchronizationCriteria.Time, 
+            TransferOptions options = null);
+        
+        CommandExecutionResult ExecuteCommand(string command);
+        
+        RemoteFileInfo GetFileInfo(string path);
+        bool TryGetFileInfo(string path, out RemoteFileInfo fileInfo);
+        bool FileExists(string path);
+        byte[] CalculateFileChecksum(string algorithm, string path);
+        
+        void CreateDirectory(string path);
+        void MoveFile(string sourcePath, string targetPath);
+        void DuplicateFile(string sourcePath, string targetPath);
+        
+        void AddRawConfiguration(string setting, string value);
+        
+        string EscapeFileMask(string fileMask);
+        string CombinePaths(string path1, string path2);
+        string TranslateLocalPathToRemote(string localPath, string localRoot, string remoteRoot);
+        string TranslateRemotePathToLocal(string remotePath, string remoteRoot, string localRoot);
+    }
+}

--- a/dotnet/Interfaces/ISessionOptions.cs
+++ b/dotnet/Interfaces/ISessionOptions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Security;
+
+namespace WinSCP
+{
+    public interface ISessionOptions
+    {
+        string Name { get; set; }
+        Protocol Protocol { get; set; }
+        string HostName { get; set; }
+        int PortNumber { get; set; }
+        string UserName { get; set; }
+        string Password { get; set; }
+        SecureString SecurePassword { get; set; }
+        string NewPassword { get; set; }
+        SecureString SecureNewPassword { get; set; }
+        TimeSpan Timeout { get; set; }
+        int TimeoutInMilliseconds { get; set; }
+        string PrivateKeyPassphrase { get; set; }
+        SecureString SecurePrivateKeyPassphrase { get; set; }
+        string RootPath { get; set; }
+        bool Secure { get; set; }
+        
+        // SSH specific
+        string SshHostKeyFingerprint { get; set; }
+        SshHostKeyPolicy SshHostKeyPolicy { get; set; }
+        string SshPrivateKeyPath { get; set; }
+        string SshPrivateKey { get; set; }
+        
+        // FTP specific
+        FtpMode FtpMode { get; set; }
+        FtpSecure FtpSecure { get; set; }
+        
+        // TLS specific
+        string TlsHostCertificateFingerprint { get; set; }
+        bool GiveUpSecurityAndAcceptAnyTlsHostCertificate { get; set; }
+        string TlsClientCertificatePath { get; set; }
+        
+        void AddRawSettings(string setting, string value);
+    }
+}

--- a/dotnet/Interfaces/ITransferOptions.cs
+++ b/dotnet/Interfaces/ITransferOptions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace WinSCP
+{
+    public interface ITransferOptions
+    {
+        bool PreserveTimestamp { get; set; }
+        FilePermissions FilePermissions { get; set; }
+        TransferMode TransferMode { get; set; }
+        string FileMask { get; set; }
+        TransferResumeSupport ResumeSupport { get; set; }
+        int SpeedLimit { get; set; }
+        OverwriteMode OverwriteMode { get; set; }
+        
+        void AddRawSettings(string setting, string value);
+    }
+}

--- a/dotnet/OperationResultBase.cs
+++ b/dotnet/OperationResultBase.cs
@@ -5,7 +5,7 @@ namespace WinSCP
     [Guid("B4CC583A-B64E-4797-9967-0FCB2F07C977")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public class OperationResultBase
+    public class OperationResultBase : IOperationResultBase
     {
         public SessionRemoteExceptionCollection Failures { get; private set; }
 

--- a/dotnet/RemoteDirectoryInfo.cs
+++ b/dotnet/RemoteDirectoryInfo.cs
@@ -5,7 +5,7 @@ namespace WinSCP
     [Guid("FBE2FACF-F1D5-493D-9E41-4B9B7243A676")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class RemoteDirectoryInfo
+    public sealed class RemoteDirectoryInfo : IRemoteDirectoryInfo
     {
         public RemoteFileInfoCollection Files { get; private set; }
 

--- a/dotnet/RemoteFileInfo.cs
+++ b/dotnet/RemoteFileInfo.cs
@@ -7,7 +7,7 @@ namespace WinSCP
     [Guid("17FF9C92-B8B6-4506-A7BA-8482D9B0AB07")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class RemoteFileInfo
+    public sealed class RemoteFileInfo : IRemoteFileInfo
     {
         public string Name { get; internal set; }
         public string FullName { get; internal set; }

--- a/dotnet/RemovalOperationResult.cs
+++ b/dotnet/RemovalOperationResult.cs
@@ -5,7 +5,7 @@ namespace WinSCP
     [Guid("3BCB18EC-6D98-4BFB-A9C2-893CBD13CDAB")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class RemovalOperationResult : OperationResultBase
+    public sealed class RemovalOperationResult : OperationResultBase, IRemovalOperationResult
     {
         public RemovalEventArgsCollection Removals { get; private set; }
 

--- a/dotnet/Session.cs
+++ b/dotnet/Session.cs
@@ -70,7 +70,7 @@ namespace WinSCP
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
     [ComSourceInterfaces(typeof(ISessionEvents))]
-    public sealed class Session : IDisposable, IReflect
+    public sealed class Session : ISession, IReflect
     {
         public string ExecutablePath { get { return GetExecutablePath(); } set { CheckNotOpened(); _executablePath = value; } }
 #if !NETSTANDARD

--- a/dotnet/SessionOptions.cs
+++ b/dotnet/SessionOptions.cs
@@ -47,7 +47,7 @@ namespace WinSCP
     [Guid("2D4EF368-EE80-4C15-AE77-D12AEAF4B00A")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class SessionOptions
+    public sealed class SessionOptions : ISessionOptions
     {
         public SessionOptions()
         {

--- a/dotnet/SynchronizationResult.cs
+++ b/dotnet/SynchronizationResult.cs
@@ -5,7 +5,7 @@ namespace WinSCP
     [Guid("D0ADB4F7-47AE-43AC-AA41-9114650EA51A")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class SynchronizationResult : OperationResultBase
+    public sealed class SynchronizationResult : OperationResultBase, ISynchronizationResult
     {
         public TransferEventArgsCollection Uploads { get; private set; }
         public TransferEventArgsCollection Downloads { get; private set; }

--- a/dotnet/TransferOperationResult.cs
+++ b/dotnet/TransferOperationResult.cs
@@ -5,7 +5,7 @@ namespace WinSCP
     [Guid("74F668E6-8EF2-4D01-84D8-DA2FE619C062")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class TransferOperationResult : OperationResultBase
+    public sealed class TransferOperationResult : OperationResultBase, ITransferOperationResult
     {
         public TransferEventArgsCollection Transfers { get; private set; }
 

--- a/dotnet/TransferOptions.cs
+++ b/dotnet/TransferOptions.cs
@@ -26,7 +26,7 @@ namespace WinSCP
     [Guid("155B841F-39D4-40C8-BA87-C79675E14CE3")]
     [ClassInterface(Constants.ClassInterface)]
     [ComVisible(true)]
-    public sealed class TransferOptions
+    public sealed class TransferOptions : ITransferOptions
     {
         public bool PreserveTimestamp { get; set; }
         public FilePermissions FilePermissions { get; set; }


### PR DESCRIPTION
Add interfaces to .NET assembly for improved testability
This PR extracts interfaces from the main WinSCP .NET assembly classes (`Session`, `SessionOptions`, `TransferOptions`,  etc.), enabling:

  - Unit testing - Mock `ISession` to test code that uses WinSCP without requiring actual SFTP/FTP connections
  - Dependency injection - Register interfaces in DI containers for cleaner architecture
  - Decoupling - Program against abstractions rather than concrete implementations

This change should be non-breaking, but I'm new to this project so review and feedback appreciated!