### PR TITLE
Avoid unnecessary path canonicalization in clipboard fake-directory monitor

### DIFF
--- a/source/forms/CustomScpExplorer.cpp
+++ b/source/forms/CustomScpExplorer.cpp
@@ -11604,10 +11604,11 @@ void __fastcall TCustomScpExplorerForm::ClipboardFakeCreated(TObject * /*Sender*
   // It can actually rarelly happen that some random file is created, while we are shutting down the monitor
   // (as it pumps a Windows message queue while being shutted down)
   if (DebugAlwaysTrue(!FClipboardFakeDirectory.IsEmpty()) &&
+      SameText(ExtractFileName(FileName), ExtractFileName(FClipboardFakeDirectory)) &&
       // Is can happen that creation of our temporary directory is detected (even though we are creating it before starting the monitors).
       // It tent do happen with later copy-pastes, probably because everything is cached already and monitors start quickly.
-      !IsPathToSameFile(FClipboardFakeDirectory, FileName) &&
-      SameText(ExtractFileName(FileName), ExtractFileName(FClipboardFakeDirectory)))
+      // Keep the cheap name check before IsPathToSameFile, as that can touch a network-backed path.
+      !IsPathToSameFile(FClipboardFakeDirectory, FileName))
   {
     AppLogFmt(L"Fake clipboard directory pasted to \"%s\"", (FileName));
     FClipboardPasteTarget = FileName;


### PR DESCRIPTION
Summary:
- Check the generated fake directory name before comparing canonical paths in `ClipboardFakeCreated`.
- This improves the order of operations so broad directory monitor notifications do not call `IsPathToSameFile` for unrelated paths.
- `IsPathToSameFile` canonicalizes paths, so applying the cheap basename check first avoids unnecessary filesystem work.

Testing:
- Not built locally; I do not have the C++Builder/Windows build environment available.
- Ran `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`.